### PR TITLE
Renamed variant

### DIFF
--- a/performance/examples/basic_test.rs
+++ b/performance/examples/basic_test.rs
@@ -190,7 +190,7 @@ fn alice_main(
                         Ok((Unassociated, _)) => {
                             //println!("[alice] ok");
                         }
-                        Ok((SessionEvent(_, event), _)) => match event {
+                        Ok((Associated(_, event), _)) => match event {
                             Established => {
                                 up = true;
                             }
@@ -279,7 +279,7 @@ fn bob_main(
                     &mut output_data,
                 ) {
                     Ok((Unassociated, _)) => {}
-                    Ok((SessionEvent(s, event), _)) => match event {
+                    Ok((Associated(s, event), _)) => match event {
                         NewSession | NewDowngradedSession => {
                             println!("[bob] new session, took {}s", current_time as f32 / 1000.0);
                             let _ = bob_session.replace(s);

--- a/performance/examples/benchmark.rs
+++ b/performance/examples/benchmark.rs
@@ -159,7 +159,7 @@ fn alice_main(
                     Ok((Unassociated, _)) => {
                         //println!("[alice] ok");
                     }
-                    Ok((SessionEvent(_, event), _)) => match event {
+                    Ok((Associated(_, event), _)) => match event {
                         Established => {
                             up = true;
                         }
@@ -239,7 +239,7 @@ fn bob_main(
                 &mut output_data,
             ) {
                 Ok((Unassociated, _)) => {}
-                Ok((SessionEvent(s, event), _)) => match event {
+                Ok((Associated(s, event), _)) => match event {
                     NewSession | NewDowngradedSession => {
                         println!("[bob] new session, took {}s", current_time as f32 / 1000.0);
                         let _ = bob_session.replace(s);

--- a/performance/src/result.rs
+++ b/performance/src/result.rs
@@ -191,7 +191,7 @@ pub enum ReceiveOk<Crypto: CryptoLayer> {
     /// or if it was a control packet that does not go through full Noise authentication.
     Unassociated,
     /// Packet was authentic and belongs to this specific session.
-    SessionEvent(Arc<Session<Crypto>>, SessionEvent),
+    Associated(Arc<Session<Crypto>>, SessionEvent),
 }
 /// Something that can occur to an associated session when a packet is received successfully,
 /// including receiving a payload of decrypted, authenticated data.

--- a/performance/src/zssp.rs
+++ b/performance/src/zssp.rs
@@ -403,7 +403,7 @@ impl<Crypto: CryptoLayer> Context<Crypto> {
                         _ => return Err(fault!(InvalidPacket, true)), // This is unreachable.
                     }
                 };
-                Ok((ReceiveOk::SessionEvent(session, ret.0), ret.1))
+                Ok((ReceiveOk::Associated(session, ret.0), ret.1))
             } else {
                 // Check for and handle PACKET_TYPE_ALICE_NOISE_XK_PATTERN_3
                 let zeta = self.0.unassociated_handshake_states.get(kid_recv);
@@ -463,7 +463,7 @@ impl<Crypto: CryptoLayer> Context<Crypto> {
                         })?;
                     log!(app, X3IsAuthSentKeyConfirm(&session));
                     Ok((
-                        ReceiveOk::SessionEvent(
+                        ReceiveOk::Associated(
                             session,
                             if should_warn_missing_ratchet {
                                 SessionEvent::NewDowngradedSession


### PR DESCRIPTION
I renamed the `ReceiveOk` variant to not have any name collisions if someone tries to do `use ReceiveOk::*`. `ReceiveOk::Unassociated` and `ReceiveOk::Associated` feels more intuitive.