### PR TITLE
Fixed fragmentation

### DIFF
--- a/performance/src/proto.rs
+++ b/performance/src/proto.rs
@@ -8,6 +8,13 @@ pub const MIN_PACKET_SIZE: usize = HEADER_SIZE + AES_GCM_TAG_SIZE;
 /// If an MTU is passed to ZSSP that is lower than this, it will be ignored and instead this value
 /// will be used.
 pub const MIN_TRANSPORT_MTU: usize = 128;
+/// Returns the maximum length of `data` that can be passed to `Context::send` before it starts to
+/// return `Err(SendError::DataTooLarge)`. Must be provided with the same `mtu`,
+/// the maximum transmission unit, that is passed to `Context::send`. Keep in mind that `mtu` must
+/// be above `MIN_TRANSPORT_MTU` or else `Context::send` would return `Err(SendError::MtuTooSmall).
+pub const fn max_sendable_len(mtu: usize) -> usize {
+    (mtu - HEADER_SIZE)*MAX_FRAGMENTS - AES_GCM_TAG_SIZE
+}
 
 pub(crate) const KID_SIZE: usize = 4;
 

--- a/performance/src/result.rs
+++ b/performance/src/result.rs
@@ -234,9 +234,9 @@ pub enum SessionEvent {
     /// The received packet was some authentic protocol control packet. No action needs to be taken.
     Control,
     /// In the process of establishing a session with Bob, Bob did not have the correct ratchet key.
-    /// Bob has partially failed authentication, but we as Alice configured to only emit a warning
-    /// and still allow Bob to connect.
-    /// See `ApplicationLayer::initiator_disallows_downgrade` to alert this configuration.
+    /// Bob has partially failed authentication, but we as Alice are configured to only emit a
+    /// warning and still allow Bob to connect.
+    /// See `ApplicationLayer::initiator_disallows_downgrade` to alter this configuration.
     DowngradedRatchetKey,
 }
 

--- a/performance/src/zeta.rs
+++ b/performance/src/zeta.rs
@@ -1666,6 +1666,9 @@ pub(crate) fn send_payload<Crypto: CryptoLayer>(
     let fragment_count = tagged_payload_len.saturating_add(payload_mtu - 1) / payload_mtu; // Ceiling div.
     let fragment_base_size = tagged_payload_len / fragment_count;
     let fragment_size_remainder = tagged_payload_len % fragment_count;
+    if fragment_count > MAX_FRAGMENTS {
+        return Err(DataTooLarge);
+    }
 
     let mut header = [0u8; HEADER_SIZE];
     header[..KID_SIZE].copy_from_slice(&kid_send);

--- a/reference/src/zeta.rs
+++ b/reference/src/zeta.rs
@@ -1375,7 +1375,7 @@ pub(crate) fn received_k2_trans<App: ApplicationLayer>(
 pub(crate) fn send_payload<Crypto: CryptoLayer>(
     zeta: &mut Zeta<Crypto>,
     mut payload: Vec<u8>,
-    send: impl FnOnce(&Packet, Option<&[u8; AES_256_KEY_SIZE]>),
+    send: impl FnOnce(&Packet, Option<&[u8; AES_256_KEY_SIZE]>) -> Result<(), SendError>,
 ) -> Result<(), SendError> {
     use SendError::*;
 
@@ -1401,8 +1401,7 @@ pub(crate) fn send_payload<Crypto: CryptoLayer>(
         send(
             &Packet(zeta.key_ref(false).send.kid.unwrap().get(), n, payload),
             Some(&zeta.hk_send),
-        );
-        Ok(())
+        )
     } else {
         zeta.expire();
         Err(SessionExpired)


### PR DESCRIPTION
`Context::send` would ignore if the fragment count went above `MAX_FRAGMENTS`, which would cause the receiver to immediately drop the sent fragments because they would not fit in memory. This is now no longer the case.

Function `max_sendable_len` was added to allow a user to predict whether or not `Context::send` would return `Err(SendError::DataTooLarge)` without having to call it.