### PR TITLE
Updated p384 trait to follow the p384 spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,10 @@ members = [
     "reference",
 ]
 resolver = "2"
+
+[profile.bench]
+opt-level = 3
+strip = true
+debug = true
+codegen-units = 1
+lto = true

--- a/performance/Cargo.toml
+++ b/performance/Cargo.toml
@@ -10,9 +10,6 @@ name = "zssp"
 path = "src/lib.rs"
 doc = true
 
-[profile.bench]
-debug = true
-
 [dependencies]
 rand_core = { version = "0.6.4" }
 zeroize = { version = "1.6.0" }

--- a/performance/src/crypto_impl/p384_impl.rs
+++ b/performance/src/crypto_impl/p384_impl.rs
@@ -27,13 +27,12 @@ impl<Rng: RngCore + CryptoRng> P384KeyPair<Rng> for CrateP384KeyPair {
         CompressedPoint::from(self.public_key()).as_slice().try_into().unwrap()
     }
 
-    fn agree(&self, public_key: &Self::PublicKey, output: &mut [u8; P384_ECDH_SHARED_SECRET_SIZE]) -> bool {
+    fn agree(&self, public_key: &Self::PublicKey, output: &mut [u8; P384_ECDH_SHARED_SECRET_SIZE]) {
         *output = self
             .diffie_hellman(public_key)
             .raw_secret_bytes()
             .as_slice()
             .try_into()
             .unwrap();
-        true
     }
 }

--- a/performance/src/result.rs
+++ b/performance/src/result.rs
@@ -13,7 +13,7 @@ pub enum OpenError {
     IdentityTooLarge,
 
     /// An error was returned by one of the ratchet state `ApplicationLayer` callbacks.
-    /// The received packet was dropped.
+    /// The session could not be openned as a result.
     StorageError(std::io::Error),
 }
 

--- a/performance/src/result.rs
+++ b/performance/src/result.rs
@@ -9,9 +9,6 @@ use crate::zeta::Session;
 /// Depending on the error type trying again may not work.
 #[derive(Debug)]
 pub enum OpenError {
-    /// An invalid parameter was supplied to the function.
-    InvalidPublicKey,
-
     /// The given identity string was larger than `IDENTITY_MAX_SIZE`, a.k.a. 4096 bytes.
     IdentityTooLarge,
 
@@ -243,7 +240,6 @@ pub enum SessionEvent {
 impl Display for OpenError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OpenError::InvalidPublicKey => f.write_str("invalid public key"),
             OpenError::IdentityTooLarge => f.write_str("identity too large"),
             OpenError::StorageError(e) => e.fmt(f),
         }

--- a/performance/src/zeta.rs
+++ b/performance/src/zeta.rs
@@ -1797,6 +1797,7 @@ impl<Crypto: CryptoLayer> Session<Crypto> {
         self.state.read().unwrap().ratchet_state1.chain_len
     }
     /// Check whether this session is established and can send data.
+    ///
     /// Expired sessions will return false.
     pub fn established(&self) -> bool {
         !matches!(
@@ -1805,6 +1806,8 @@ impl<Crypto: CryptoLayer> Session<Crypto> {
         )
     }
     /// Check whether this session is still in the establishing phase of the handshake.
+    /// Sessions that are establishing are not capable of sending data.
+    ///
     /// Expired sessions will return false.
     pub fn establishing(&self) -> bool {
         matches!(
@@ -1813,7 +1816,7 @@ impl<Crypto: CryptoLayer> Session<Crypto> {
         )
     }
     /// Check whether this session is expired and can no longer be used.
-    pub fn expired(&self) -> bool {
+    pub fn is_expired(&self) -> bool {
         matches!(&self.state.read().unwrap().beta, ZetaAutomata::Null)
     }
     /// The static public key of the remote peer.

--- a/reference/src/crypto/p384.rs
+++ b/reference/src/crypto/p384.rs
@@ -41,5 +41,5 @@ pub trait P384KeyPair<Rng: RngCore + CryptoRng> {
     /// the input `public_key` key would result in an invalid, non-standard or predictable ECDH secret.
     /// Please refer to the NIST spec for P-384 ECDH key agreement, or better yet use a peer reviewed
     /// library that has already implemented this correctly.
-    fn agree(&self, public_key: &Self::PublicKey) -> Option<[u8; P384_ECDH_SHARED_SECRET_SIZE]>;
+    fn agree(&self, public_key: &Self::PublicKey) -> [u8; P384_ECDH_SHARED_SECRET_SIZE];
 }

--- a/reference/src/crypto_impl/p384_impl.rs
+++ b/reference/src/crypto_impl/p384_impl.rs
@@ -29,13 +29,11 @@ impl<Rng: RngCore + CryptoRng> P384KeyPair<Rng> for P384CrateKeyPair {
         CompressedPoint::from(self.public_key()).as_slice().try_into().unwrap()
     }
 
-    fn agree(&self, public_key: &Self::PublicKey) -> Option<[u8; P384_ECDH_SHARED_SECRET_SIZE]> {
-        Some(
-            self.diffie_hellman(public_key)
-                .raw_secret_bytes()
-                .as_slice()
-                .try_into()
-                .unwrap(),
-        )
+    fn agree(&self, public_key: &Self::PublicKey) -> [u8; P384_ECDH_SHARED_SECRET_SIZE] {
+        self.diffie_hellman(public_key)
+            .raw_secret_bytes()
+            .as_slice()
+            .try_into()
+            .unwrap()
     }
 }

--- a/reference/src/result.rs
+++ b/reference/src/result.rs
@@ -13,7 +13,7 @@ pub enum OpenError {
     IdentityTooLarge,
 
     /// An error was returned by one of the ratchet state `ApplicationLayer` callbacks.
-    /// The received packet was dropped.
+    /// The session could not be openned as a result.
     StorageError(std::io::Error),
 }
 

--- a/reference/src/result.rs
+++ b/reference/src/result.rs
@@ -9,9 +9,6 @@ use crate::zeta::Session;
 /// Depending on the error type trying again may not work.
 #[derive(Debug)]
 pub enum OpenError {
-    /// An invalid parameter was supplied to the function.
-    InvalidPublicKey,
-
     /// The given identity string was larger than `IDENTITY_MAX_SIZE`, a.k.a. 4096 bytes.
     IdentityTooLarge,
 
@@ -243,7 +240,6 @@ pub enum SessionEvent {
 impl Display for OpenError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OpenError::InvalidPublicKey => f.write_str("invalid public key"),
             OpenError::IdentityTooLarge => f.write_str("identity too large"),
             OpenError::StorageError(e) => e.fmt(f),
         }


### PR DESCRIPTION
Updated p384 trait to follow the p384 spec. Key agreement was changed to never be able to fail. This removes a lot of unnecessary error handling.