### PR TITLE
Switch to `parking_lot` primitives

### DIFF
--- a/performance/Cargo.toml
+++ b/performance/Cargo.toml
@@ -19,6 +19,7 @@ p384 = { version = "0.13.0", default-features = false, features = ["ecdh"], opti
 sha2 = { version = "0.10.7", default-features = false, optional = true }
 hmac = { version = "0.12.1", default-features = false, optional = true }
 openssl-sys = { version = "0.9.91", default-features = false, optional = true }
+parking_lot = { version = "0.12.1", features = ["hardware-lock-elision"] }
 
 [features]
 default = ["debug", "default-crypto"]

--- a/performance/examples/benchmark.rs
+++ b/performance/examples/benchmark.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc};
+use parking_lot::Mutex;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -25,14 +26,14 @@ struct TestApplication {
 struct PooledVec(Vec<u8>);
 static POOL: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
 fn alloc(b: &[u8]) -> PooledVec {
-    let mut p = POOL.lock().unwrap();
+    let mut p = POOL.lock();
     let mut v = p.pop().unwrap_or_default();
     v.extend(b);
     PooledVec(v)
 }
 impl Drop for PooledVec {
     fn drop(&mut self) {
-        let mut p = POOL.lock().unwrap();
+        let mut p = POOL.lock();
         let mut v = Vec::new();
         std::mem::swap(&mut self.0, &mut v);
         v.clear();

--- a/performance/src/frag_cache.rs
+++ b/performance/src/frag_cache.rs
@@ -231,10 +231,10 @@ impl<C: CryptoLayer> Drop for UnassociatedFragCache<C> {
 
 #[test]
 fn test_cache() {
-    use std::sync::Mutex;
+    use parking_lot::Mutex;
     fn xorshift64_random() -> u64 {
         static XORSHIFT64_STATE: Mutex<u64> = Mutex::new(12);
-        let mut x = XORSHIFT64_STATE.lock().unwrap();
+        let mut x = XORSHIFT64_STATE.lock();
         *x ^= x.wrapping_shr(12);
         *x ^= x.wrapping_shl(25);
         *x ^= x.wrapping_shr(27);


### PR DESCRIPTION
I saw that there were Mutexes and RwLocks being used widely in the performance version but that it was using `std`'s primitives. `parking_lot` is widely used and tested and it's primitives increased the benchmarked throughput from 2.1GB/s to 3.1GB/s (ish) with little change to the code. 